### PR TITLE
Potential fix for code scanning alert no. 21: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,6 @@
+name: Rust
 permissions:
   contents: read
-name: Rust
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/WendellXY/langcodec/security/code-scanning/21](https://github.com/WendellXY/langcodec/security/code-scanning/21)

To fix the problem, you should explicitly set a `permissions` block at the top-level of the workflow, just below the workflow name (line 2), to restrict the GitHub token granted to jobs. The minimal necessary permission for a typical Rust CI workflow (build, test, and checkout) is `contents: read`, meaning only read access to repository contents is allowed and no write actions take place. Place the following block immediately after the `name: Rust` line:

```yaml
permissions:
  contents: read
```

This ensures all jobs have reduced token privileges and complies with the least-privilege principle, without affecting any existing functionalities.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
