### PR TITLE
Potential fix for code scanning alert no. 22: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/clippy-check.yml
+++ b/.github/workflows/clippy-check.yml
@@ -1,5 +1,7 @@
 on: push
 name: Clippy check
+permissions:
+  contents: read
 
 # Make sure CI fails on all warnings, including Clippy lints
 env:


### PR DESCRIPTION
Potential fix for [https://github.com/WendellXY/langcodec/security/code-scanning/22](https://github.com/WendellXY/langcodec/security/code-scanning/22)

To resolve this issue, we should explicitly set the permissions for the workflow to ensure that only the least privilege necessary is provided. Since the Clippy check job only needs to read the repository code, the best-practice is to set `permissions: contents: read` at the workflow level (that is, near the top of the file, alongside `on` and `name`), so that it applies for all jobs unless overridden. This fixes the error by explicitly limiting the default GITHUB_TOKEN permissions for the workflow.

The required change is to insert the following lines after the `name:` key and before `env:`, or simply at the top below `name:`:

```yaml
permissions:
  contents: read
```

No imports, methods, or other definitions are needed, as this is a pure YAML configuration change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
