### PR TITLE
feat: plural rules engine, validation reports, CLI integration, and autofix

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ This is a `0.4.0` release available on [crates.io](https://crates.io/crates/lang
 - Stats (JSON): `langcodec stats -i Localizable.xcstrings --json`
   - See full options: langcodec-cli/README.md#stats
   - Example output:
+  
     ```json
     {
       "summary": { "languages": 1, "unique_keys": 42 },

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,10 +22,10 @@ Legend: [ ] todo, [x] done, [~] in progress
   - [x] Detect placeholder mismatches across languages; strict vs non‑strict modes
   - [x] Auto‑fix option for common cases (`normalize_placeholders_in_place`)
   - [x] Tests across singular and plural entries; cross‑language normalization
-- [ ] Plural rules engine
-  - [ ] CLDR‑driven required category sets per locale (few/many/etc.)
-  - [ ] Validation pass: flag missing categories per key+locale
-  - [ ] CLI: `view --check-plurals` and `validate` output
+- [~] Plural rules engine
+  - [x] CLDR‑driven required category sets per locale (few/many/etc.)
+  - [x] Validation pass: flag missing categories per key+locale
+  - [~] CLI: `view --check-plurals` and `validate` output
 - [ ] Strict vs. permissive parsing
   - [ ] Global setting in lib; CLI `--strict` flag
   - [ ] Consistent error surfaces with actionable context

--- a/langcodec-cli/Cargo.toml
+++ b/langcodec-cli/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["command-line-utilities", "internationalization", "localization"]
 documentation = "https://docs.rs/langcodec-cli"
 
 [dependencies]
-langcodec = "0.4.1"
+langcodec = { path = "../langcodec", version = "0.4.1" }
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 unicode-width = "0.2.1"

--- a/langcodec-cli/src/main.rs
+++ b/langcodec-cli/src/main.rs
@@ -191,7 +191,12 @@ fn main() {
                 },
             );
         }
-        Commands::View { input, lang, full, check_plurals } => {
+        Commands::View {
+            input,
+            lang,
+            full,
+            check_plurals,
+        } => {
             // Create validation context
             let mut context = ValidationContext::new().with_input_file(input.clone());
 

--- a/langcodec-cli/src/main.rs
+++ b/langcodec-cli/src/main.rs
@@ -74,6 +74,10 @@ enum Commands {
         /// Display full value without truncation (even in terminal)
         #[arg(long)]
         full: bool,
+
+        /// Validate plural completeness against CLDR category sets
+        #[arg(long, default_value_t = false)]
+        check_plurals: bool,
     },
 
     /// Merge multiple localization files into one output file with automatic format detection and conversion.
@@ -187,7 +191,7 @@ fn main() {
                 },
             );
         }
-        Commands::View { input, lang, full } => {
+        Commands::View { input, lang, full, check_plurals } => {
             // Create validation context
             let mut context = ValidationContext::new().with_input_file(input.clone());
 
@@ -223,6 +227,16 @@ fn main() {
             }
 
             print_view(&codec, &lang, full);
+
+            if check_plurals {
+                match codec.validate_plurals() {
+                    Ok(()) => println!("\n✅ Plural validation passed"),
+                    Err(e) => {
+                        eprintln!("\n❌ Plural validation failed: {}", e);
+                        std::process::exit(2);
+                    }
+                }
+            }
         }
         Commands::Merge {
             inputs,

--- a/langcodec-cli/src/stats.rs
+++ b/langcodec-cli/src/stats.rs
@@ -1,4 +1,4 @@
-use langcodec::{collect_resource_plural_issues, Codec, types::EntryStatus};
+use langcodec::{Codec, collect_resource_plural_issues, types::EntryStatus};
 use serde_json::json;
 use std::collections::HashMap;
 

--- a/langcodec-cli/src/stats.rs
+++ b/langcodec-cli/src/stats.rs
@@ -1,4 +1,4 @@
-use langcodec::{Codec, types::EntryStatus};
+use langcodec::{collect_resource_plural_issues, Codec, types::EntryStatus};
 use serde_json::json;
 use std::collections::HashMap;
 
@@ -46,6 +46,10 @@ pub fn print_stats(codec: &Codec, lang_filter: &Option<String>, json_output: boo
             for e in &res.entries {
                 accumulate(&mut stats, &e.status);
             }
+            let plural_issues = collect_resource_plural_issues(res);
+            let missing_plural_entries = plural_issues.len();
+            let missing_plural_categories_total: usize =
+                plural_issues.iter().map(|r| r.missing.len()).sum();
             let percent = if stats.denominator == 0 {
                 100.0
             } else {
@@ -56,6 +60,8 @@ pub fn print_stats(codec: &Codec, lang_filter: &Option<String>, json_output: boo
                 "total": stats.total,
                 "by_status": stats.by_status,
                 "completion_percent": (percent * 100.0).round() / 100.0,
+                "missing_plural_entries": missing_plural_entries,
+                "missing_plural_categories_total": missing_plural_categories_total,
             }));
         }
         let summary = json!({
@@ -79,6 +85,10 @@ pub fn print_stats(codec: &Codec, lang_filter: &Option<String>, json_output: boo
         for e in &res.entries {
             accumulate(&mut stats, &e.status);
         }
+        let plural_issues = collect_resource_plural_issues(res);
+        let missing_plural_entries = plural_issues.len();
+        let missing_plural_categories_total: usize =
+            plural_issues.iter().map(|r| r.missing.len()).sum();
         let percent = if stats.denominator == 0 {
             100.0
         } else {
@@ -110,5 +120,9 @@ pub fn print_stats(codec: &Codec, lang_filter: &Option<String>, json_output: boo
             println!("    {}: {}", k, v);
         }
         println!("  Completion: {:.2}%", percent);
+        println!(
+            "  Missing plurals: {} (missing categories: {})",
+            missing_plural_entries, missing_plural_categories_total
+        );
     }
 }

--- a/langcodec-cli/tests/plural_validation_cli_tests.rs
+++ b/langcodec-cli/tests/plural_validation_cli_tests.rs
@@ -1,0 +1,82 @@
+use std::fs;
+use std::process::Command;
+use tempfile::TempDir;
+
+#[test]
+fn test_cli_view_check_plurals_fails_on_missing() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_file = temp_dir.path().join("strings.xml");
+
+    // English requires 'one' and 'other'; provide only 'other'
+    let xml = r#"
+        <resources>
+            <plurals name="apples" translatable="true">
+                <item quantity="other">%d apples</item>
+            </plurals>
+        </resources>
+    "#;
+    fs::write(&input_file, xml).unwrap();
+
+    let output = Command::new("cargo")
+        .args([
+            "run",
+            "--quiet",
+            "--",
+            "view",
+            "-i",
+            input_file.to_str().unwrap(),
+            "--lang",
+            "en",
+            "--check-plurals",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "CLI unexpectedly succeeded: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Plural validation failed"), "stderr: {}", stderr);
+}
+
+#[test]
+fn test_cli_view_check_plurals_passes_when_complete() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_file = temp_dir.path().join("strings.xml");
+
+    // English: provide 'one' and 'other'
+    let xml = r#"
+        <resources>
+            <plurals name="apples" translatable="true">
+                <item quantity="one">One apple</item>
+                <item quantity="other">%d apples</item>
+            </plurals>
+        </resources>
+    "#;
+    fs::write(&input_file, xml).unwrap();
+
+    let output = Command::new("cargo")
+        .args([
+            "run",
+            "--quiet",
+            "--",
+            "view",
+            "-i",
+            input_file.to_str().unwrap(),
+            "--lang",
+            "en",
+            "--check-plurals",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "CLI failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("✅ Plural validation passed"));
+}

--- a/langcodec-cli/tests/plural_validation_cli_tests.rs
+++ b/langcodec-cli/tests/plural_validation_cli_tests.rs
@@ -38,7 +38,11 @@ fn test_cli_view_check_plurals_fails_on_missing() {
         String::from_utf8_lossy(&output.stdout)
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("Plural validation failed"), "stderr: {}", stderr);
+    assert!(
+        stderr.contains("Plural validation failed"),
+        "stderr: {}",
+        stderr
+    );
 }
 
 #[test]

--- a/langcodec/README.md
+++ b/langcodec/README.md
@@ -13,7 +13,7 @@ Universal localization file toolkit for Rust. Parse, write, convert, merge.
 langcodec = "0.4.0"
 ```
 
-Docs: https://docs.rs/langcodec
+Docs: <https://docs.rs/langcodec>
 
 ## Quick Start
 

--- a/langcodec/src/codec.rs
+++ b/langcodec/src/codec.rs
@@ -656,6 +656,17 @@ impl Codec {
         reports
     }
 
+    /// Autofix: fill missing plural categories using 'other' and mark entries as NeedsReview.
+    /// Returns total categories added across all resources.
+    pub fn autofix_fill_missing_from_other(&mut self) -> usize {
+        use crate::plural_rules::autofix_fill_missing_from_other_resource;
+        let mut total = 0usize;
+        for res in &mut self.resources {
+            total += autofix_fill_missing_from_other_resource(res);
+        }
+        total
+    }
+
     /// Cleans up resources by removing empty resources and entries.
     pub fn clean_up_resources(&mut self) {
         self.resources

--- a/langcodec/src/lib.rs
+++ b/langcodec/src/lib.rs
@@ -145,6 +145,7 @@ pub mod formats;
 pub mod placeholder;
 pub mod traits;
 pub mod types;
+pub mod plural_rules;
 
 // Re-export most used types for easy consumption
 pub use crate::{
@@ -158,6 +159,7 @@ pub use crate::{
     error::Error,
     formats::FormatType,
     placeholder::{extract_placeholders, normalize_placeholders, signature},
+    plural_rules::{required_categories_for_str, validate_resource_plurals},
     types::{
         ConflictStrategy, Entry, EntryStatus, Metadata, Plural, PluralCategory, Resource,
         Translation,

--- a/langcodec/src/lib.rs
+++ b/langcodec/src/lib.rs
@@ -143,9 +143,9 @@ pub mod converter;
 pub mod error;
 pub mod formats;
 pub mod placeholder;
+pub mod plural_rules;
 pub mod traits;
 pub mod types;
-pub mod plural_rules;
 
 // Re-export most used types for easy consumption
 pub use crate::{
@@ -160,8 +160,8 @@ pub use crate::{
     formats::FormatType,
     placeholder::{extract_placeholders, normalize_placeholders, signature},
     plural_rules::{
-        autofix_fill_missing_from_other_resource, collect_resource_plural_issues,
-        required_categories_for_str, validate_resource_plurals, PluralValidationReport,
+        PluralValidationReport, autofix_fill_missing_from_other_resource,
+        collect_resource_plural_issues, required_categories_for_str, validate_resource_plurals,
     },
     types::{
         ConflictStrategy, Entry, EntryStatus, Metadata, Plural, PluralCategory, Resource,

--- a/langcodec/src/lib.rs
+++ b/langcodec/src/lib.rs
@@ -160,8 +160,8 @@ pub use crate::{
     formats::FormatType,
     placeholder::{extract_placeholders, normalize_placeholders, signature},
     plural_rules::{
-        collect_resource_plural_issues, required_categories_for_str, validate_resource_plurals,
-        PluralValidationReport,
+        autofix_fill_missing_from_other_resource, collect_resource_plural_issues,
+        required_categories_for_str, validate_resource_plurals, PluralValidationReport,
     },
     types::{
         ConflictStrategy, Entry, EntryStatus, Metadata, Plural, PluralCategory, Resource,

--- a/langcodec/src/lib.rs
+++ b/langcodec/src/lib.rs
@@ -159,7 +159,10 @@ pub use crate::{
     error::Error,
     formats::FormatType,
     placeholder::{extract_placeholders, normalize_placeholders, signature},
-    plural_rules::{required_categories_for_str, validate_resource_plurals},
+    plural_rules::{
+        collect_resource_plural_issues, required_categories_for_str, validate_resource_plurals,
+        PluralValidationReport,
+    },
     types::{
         ConflictStrategy, Entry, EntryStatus, Metadata, Plural, PluralCategory, Resource,
         Translation,

--- a/langcodec/src/plural_rules.rs
+++ b/langcodec/src/plural_rules.rs
@@ -192,15 +192,17 @@ pub fn autofix_fill_missing_from_other_resource(resource: &mut Resource) -> usiz
             }
             // Need an 'other' form to duplicate
             if let Some(other_val) = plural.forms.get(&PluralCategory::Other).cloned() {
+                let mut added_here = 0usize;
                 for cat in missing {
                     // Insert only if still missing (avoid race with duplicates)
                     if let std::collections::btree_map::Entry::Vacant(e) = plural.forms.entry(cat) {
                         e.insert(other_val.clone());
                         added += 1;
+                        added_here += 1;
                     }
                 }
                 // Mark as needs review if anything was added
-                if added > 0 && !matches!(entry.status, EntryStatus::NeedsReview) {
+                if added_here > 0 && !matches!(entry.status, EntryStatus::NeedsReview) {
                     entry.status = EntryStatus::NeedsReview;
                 }
             }

--- a/langcodec/src/plural_rules.rs
+++ b/langcodec/src/plural_rules.rs
@@ -1,0 +1,245 @@
+use std::collections::BTreeSet;
+
+use unic_langid::LanguageIdentifier;
+
+use crate::{
+    error::Error,
+    types::{Plural, PluralCategory, Resource, Translation},
+};
+
+/// Returns the required CLDR plural categories for a given language identifier.
+///
+/// This is a curated subset of CLDR rules covering common locales. For unknown
+/// or unsupported locales, falls back to {Other} to avoid false positives.
+pub fn required_categories_for(lang: &LanguageIdentifier) -> BTreeSet<PluralCategory> {
+    let mut set: BTreeSet<PluralCategory> = BTreeSet::new();
+
+    // Base language subtag only for rule selection
+    let lang_str = lang.language.as_str();
+
+    match lang_str {
+        // One/Other languages (most European languages)
+        "en" | "de" | "nl" | "sv" | "da" | "nb" | "nn" | "no" | "is" | "fi" | "et"
+        | "fa" | "hi" | "bn" | "gu" | "ta" | "te" | "kn" | "ml" | "mr" | "it"
+        | "es" | "pt" | "pt_br" | "pt_pt" | "mk" | "el" | "eu" | "gl" | "af" | "sw"
+        | "ur" | "fil" | "tl" | "tr" | "id" | "ms" => {
+            set.insert(PluralCategory::One);
+            set.insert(PluralCategory::Other);
+        }
+
+        // Only Other (East Asian languages and some SE Asian)
+        "ja" | "zh" | "ko" | "th" | "vi" | "km" | "lo" | "my" | "yue" | "zh_hant"
+        | "zh_hans" => {
+            set.insert(PluralCategory::Other);
+        }
+
+        // French-like (CLDR: one/other)
+        "fr" | "hy" | "kab" => {
+            set.insert(PluralCategory::One);
+            set.insert(PluralCategory::Other);
+        }
+
+        // Slavic (Russian group): one, few, many, other
+        "ru" | "uk" | "be" | "sr" | "hr" | "bs" | "sh" => {
+            set.insert(PluralCategory::One);
+            set.insert(PluralCategory::Few);
+            set.insert(PluralCategory::Many);
+            set.insert(PluralCategory::Other);
+        }
+
+        // Polish: one, few, many, other
+        "pl" => {
+            set.insert(PluralCategory::One);
+            set.insert(PluralCategory::Few);
+            set.insert(PluralCategory::Many);
+            set.insert(PluralCategory::Other);
+        }
+
+        // Czech/Slovak: one, few, other
+        "cs" | "sk" => {
+            set.insert(PluralCategory::One);
+            set.insert(PluralCategory::Few);
+            set.insert(PluralCategory::Other);
+        }
+
+        // Slovenian: one, two, few, other
+        "sl" => {
+            set.insert(PluralCategory::One);
+            set.insert(PluralCategory::Two);
+            set.insert(PluralCategory::Few);
+            set.insert(PluralCategory::Other);
+        }
+
+        // Lithuanian: one, few, other
+        "lt" => {
+            set.insert(PluralCategory::One);
+            set.insert(PluralCategory::Few);
+            set.insert(PluralCategory::Other);
+        }
+
+        // Latvian: zero, one, other
+        "lv" => {
+            set.insert(PluralCategory::Zero);
+            set.insert(PluralCategory::One);
+            set.insert(PluralCategory::Other);
+        }
+
+        // Irish Gaelic: one, two, few, many, other
+        "ga" => {
+            set.insert(PluralCategory::One);
+            set.insert(PluralCategory::Two);
+            set.insert(PluralCategory::Few);
+            set.insert(PluralCategory::Many);
+            set.insert(PluralCategory::Other);
+        }
+
+        // Romanian: one, few, other
+        "ro" => {
+            set.insert(PluralCategory::One);
+            set.insert(PluralCategory::Few);
+            set.insert(PluralCategory::Other);
+        }
+
+        // Arabic: zero, one, two, few, many, other
+        "ar" => {
+            set.insert(PluralCategory::Zero);
+            set.insert(PluralCategory::One);
+            set.insert(PluralCategory::Two);
+            set.insert(PluralCategory::Few);
+            set.insert(PluralCategory::Many);
+            set.insert(PluralCategory::Other);
+        }
+
+        // Hebrew (cardinals) commonly use one, two, many, other in CLDR
+        "iw" /* legacy */ | "he" => {
+            set.insert(PluralCategory::One);
+            set.insert(PluralCategory::Two);
+            set.insert(PluralCategory::Many);
+            set.insert(PluralCategory::Other);
+        }
+
+        _ => {
+            // Conservative default to avoid noisy validation for unknown locales
+            set.insert(PluralCategory::Other);
+        }
+    }
+
+    set
+}
+
+/// Helper for string language codes (accepts underscores, normalizes to hyphen).
+pub fn required_categories_for_str(lang: &str) -> BTreeSet<PluralCategory> {
+    let normalized = lang.replace('_', "-");
+    let parsed: LanguageIdentifier = normalized.parse().unwrap_or_else(|_| "und".parse().unwrap());
+    required_categories_for(&parsed)
+}
+
+/// Compute which required categories are missing for a given plural entry and language.
+pub fn missing_categories_for_plural(
+    lang: &LanguageIdentifier,
+    plural: &Plural,
+) -> BTreeSet<PluralCategory> {
+    let required = required_categories_for(lang);
+    let have: BTreeSet<PluralCategory> = plural.forms.keys().cloned().collect();
+    &required - &have
+}
+
+/// Validate a single resource for missing plural categories.
+pub fn validate_resource_plurals(resource: &Resource) -> Result<(), Error> {
+    let lang_id = match resource.parse_language_identifier() {
+        Some(id) => id,
+        None => {
+            return Err(Error::validation_error(format!(
+                "Invalid or missing language for resource: {}",
+                resource.metadata.language
+            )));
+        }
+    };
+
+    let mut problems: Vec<String> = Vec::new();
+
+    for entry in &resource.entries {
+        if let Translation::Plural(plural) = &entry.value {
+            let missing = missing_categories_for_plural(&lang_id, plural);
+            if !missing.is_empty() {
+                let have: Vec<String> = plural
+                    .forms
+                    .keys()
+                    .map(|k| format!("{:?}", k))
+                    .collect();
+                let miss: Vec<String> = missing.into_iter().map(|k| format!("{:?}", k)).collect();
+                problems.push(format!(
+                    "lang='{}' key='{}': missing plural categories: [{}] (have: [{}])",
+                    resource.metadata.language,
+                    entry.id,
+                    miss.join(", "),
+                    have.join(", ")
+                ));
+            }
+        }
+    }
+
+    if problems.is_empty() {
+        Ok(())
+    } else {
+        Err(Error::validation_error(format!(
+            "Plural validation failed:\n{}",
+            problems.join("\n")
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{Entry, EntryStatus, Metadata};
+
+    #[test]
+    fn test_required_categories_basic() {
+        let en: LanguageIdentifier = "en".parse().unwrap();
+        let ru: LanguageIdentifier = "ru".parse().unwrap();
+        let ja: LanguageIdentifier = "ja".parse().unwrap();
+
+        let en_set = required_categories_for(&en);
+        assert!(en_set.contains(&PluralCategory::One));
+        assert!(en_set.contains(&PluralCategory::Other));
+        assert_eq!(en_set.len(), 2);
+
+        let ru_set = required_categories_for(&ru);
+        assert!(ru_set.contains(&PluralCategory::One));
+        assert!(ru_set.contains(&PluralCategory::Few));
+        assert!(ru_set.contains(&PluralCategory::Many));
+        assert!(ru_set.contains(&PluralCategory::Other));
+        assert_eq!(ru_set.len(), 4);
+
+        let ja_set = required_categories_for(&ja);
+        assert!(ja_set.contains(&PluralCategory::Other));
+        assert_eq!(ja_set.len(), 1);
+    }
+
+    #[test]
+    fn test_validate_resource_plurals_missing() {
+        // English requires one/other; missing 'one' should fail
+        let resource = Resource {
+            metadata: Metadata {
+                language: "en".into(),
+                domain: String::new(),
+                custom: Default::default(),
+            },
+            entries: vec![Entry {
+                id: "apples".into(),
+                value: Translation::Plural(Plural::new(
+                    "apples",
+                    vec![(PluralCategory::Other, "%d apples".to_string())].into_iter(),
+                )
+                .unwrap()),
+                comment: None,
+                status: EntryStatus::Translated,
+                custom: Default::default(),
+            }],
+        };
+
+        let err = validate_resource_plurals(&resource).unwrap_err();
+        assert!(format!("{}", err).contains("missing plural categories"));
+    }
+}

--- a/langcodec/src/plural_rules.rs
+++ b/langcodec/src/plural_rules.rs
@@ -7,8 +7,8 @@ use crate::{
     types::{EntryStatus, Plural, PluralCategory, Resource, Translation},
 };
 
-use serde::Serialize;
 use lazy_static::lazy_static;
+use serde::Serialize;
 
 lazy_static! {
     /// Static mapping from base language subtag → required plural categories (CLDR‑style, cardinals).
@@ -91,21 +91,20 @@ pub struct PluralValidationReport {
 pub fn required_categories_for(lang: &LanguageIdentifier) -> BTreeSet<PluralCategory> {
     // Base language subtag only for rule selection
     let lang_str = lang.language.as_str();
-    CATEGORY_TABLE
-        .get(lang_str)
-        .cloned()
-        .unwrap_or_else(|| {
-            // Conservative default to avoid noisy validation for unknown locales
-            let mut s = BTreeSet::new();
-            s.insert(PluralCategory::Other);
-            s
-        })
+    CATEGORY_TABLE.get(lang_str).cloned().unwrap_or_else(|| {
+        // Conservative default to avoid noisy validation for unknown locales
+        let mut s = BTreeSet::new();
+        s.insert(PluralCategory::Other);
+        s
+    })
 }
 
 /// Helper for string language codes (accepts underscores, normalizes to hyphen).
 pub fn required_categories_for_str(lang: &str) -> BTreeSet<PluralCategory> {
     let normalized = lang.replace('_', "-");
-    let parsed: LanguageIdentifier = normalized.parse().unwrap_or_else(|_| "und".parse().unwrap());
+    let parsed: LanguageIdentifier = normalized
+        .parse()
+        .unwrap_or_else(|_| "und".parse().unwrap());
     required_categories_for(&parsed)
 }
 
@@ -177,7 +176,9 @@ pub fn validate_resource_plurals(resource: &Resource) -> Result<(), Error> {
 ///
 /// Returns the number of categories added across the resource.
 pub fn autofix_fill_missing_from_other_resource(resource: &mut Resource) -> usize {
-    let Some(lang_id) = resource.parse_language_identifier() else { return 0; };
+    let Some(lang_id) = resource.parse_language_identifier() else {
+        return 0;
+    };
     let mut added = 0usize;
     for entry in &mut resource.entries {
         // Skip entries that shouldn't be translated
@@ -193,8 +194,8 @@ pub fn autofix_fill_missing_from_other_resource(resource: &mut Resource) -> usiz
             if let Some(other_val) = plural.forms.get(&PluralCategory::Other).cloned() {
                 for cat in missing {
                     // Insert only if still missing (avoid race with duplicates)
-                    if !plural.forms.contains_key(&cat) {
-                        plural.forms.insert(cat, other_val.clone());
+                    if let std::collections::btree_map::Entry::Vacant(e) = plural.forms.entry(cat) {
+                        e.insert(other_val.clone());
                         added += 1;
                     }
                 }
@@ -247,11 +248,13 @@ mod tests {
             },
             entries: vec![Entry {
                 id: "apples".into(),
-                value: Translation::Plural(Plural::new(
-                    "apples",
-                    vec![(PluralCategory::Other, "%d apples".to_string())].into_iter(),
-                )
-                .unwrap()),
+                value: Translation::Plural(
+                    Plural::new(
+                        "apples",
+                        vec![(PluralCategory::Other, "%d apples".to_string())].into_iter(),
+                    )
+                    .unwrap(),
+                ),
                 comment: None,
                 status: EntryStatus::Translated,
                 custom: Default::default(),
@@ -273,11 +276,13 @@ mod tests {
             },
             entries: vec![Entry {
                 id: "apples".into(),
-                value: Translation::Plural(Plural::new(
-                    "apples",
-                    vec![(PluralCategory::Other, "%d apples".to_string())].into_iter(),
-                )
-                .unwrap()),
+                value: Translation::Plural(
+                    Plural::new(
+                        "apples",
+                        vec![(PluralCategory::Other, "%d apples".to_string())].into_iter(),
+                    )
+                    .unwrap(),
+                ),
                 comment: None,
                 status: EntryStatus::Translated,
                 custom: Default::default(),
@@ -304,11 +309,13 @@ mod tests {
             },
             entries: vec![Entry {
                 id: "apples".into(),
-                value: Translation::Plural(Plural::new(
-                    "apples",
-                    vec![(PluralCategory::Other, "%d apples".to_string())].into_iter(),
-                )
-                .unwrap()),
+                value: Translation::Plural(
+                    Plural::new(
+                        "apples",
+                        vec![(PluralCategory::Other, "%d apples".to_string())].into_iter(),
+                    )
+                    .unwrap(),
+                ),
                 comment: None,
                 status: EntryStatus::Translated,
                 custom: Default::default(),


### PR DESCRIPTION
This pull request introduces plural rules validation features to the CLI and core library, improves plural completeness reporting in stats, and updates documentation and roadmap to reflect these enhancements. The most significant changes are grouped below:

**Plural validation feature in CLI and core library:**

* Added a `--check-plurals` flag to the `view` command in `langcodec-cli`, enabling validation of plural completeness against CLDR category sets. If validation fails, the CLI exits with an error and a descriptive message. [[1]](diffhunk://#diff-b470ef180058bdeb87dccd236ecc9c862fc2c4ebe174c7ef3a34f601e701e207R77-R80) [[2]](diffhunk://#diff-b470ef180058bdeb87dccd236ecc9c862fc2c4ebe174c7ef3a34f601e701e207R235-R244) [[3]](diffhunk://#diff-b470ef180058bdeb87dccd236ecc9c862fc2c4ebe174c7ef3a34f601e701e207L190-R199) [[4]](diffhunk://#diff-77494141f36f077575df83286db4bf219ec996913fd952e6e3ecf4369e7eff80R616-R669)
* Exposed plural validation and autofix functions in the core library API (`validate_plurals`, `collect_plural_issues`, `autofix_fill_missing_from_other`) and re-exported them in `lib.rs` for CLI and library consumers. [[1]](diffhunk://#diff-77494141f36f077575df83286db4bf219ec996913fd952e6e3ecf4369e7eff80R616-R669) [[2]](diffhunk://#diff-eed4bde4938f5aa227d3aa7e93cd54cbf2ff743bab2da61dfdd65d27dc913af4R146) [[3]](diffhunk://#diff-eed4bde4938f5aa227d3aa7e93cd54cbf2ff743bab2da61dfdd65d27dc913af4R162-R165)

**Plural completeness reporting in stats:**

* Improved the stats output in the CLI to include counts of missing plural entries and missing plural categories per language, using the new plural validation functions. [[1]](diffhunk://#diff-b6b1d5d20490e76aaf494e3f83637408c3de0aa370f03dafb6843131628c6932L1-R1) [[2]](diffhunk://#diff-b6b1d5d20490e76aaf494e3f83637408c3de0aa370f03dafb6843131628c6932R49-R52) [[3]](diffhunk://#diff-b6b1d5d20490e76aaf494e3f83637408c3de0aa370f03dafb6843131628c6932R63-R64) [[4]](diffhunk://#diff-b6b1d5d20490e76aaf494e3f83637408c3de0aa370f03dafb6843131628c6932R88-R91) [[5]](diffhunk://#diff-b6b1d5d20490e76aaf494e3f83637408c3de0aa370f03dafb6843131628c6932R123-R126)

**Testing and validation:**

* Added integration tests for the CLI to ensure `--check-plurals` correctly fails when plural categories are missing and passes when they are complete.

**Documentation and roadmap updates:**

* Updated the roadmap to mark plural rules engine and CLDR-driven validation as in progress or complete, reflecting the new features.
* Updated documentation links and release notes to reflect the new version and features. [[1]](diffhunk://#diff-0a2a8249243cf6b45bcaf6f52e8cacd401b683702c27f2077c3c72759b4f37bfL16-R16) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R64)

**Dependency and packaging improvements:**

* Updated CLI dependency on `langcodec` to use a local path for development consistency.

These changes provide robust plural validation for localization workflows and improve reporting and developer experience.